### PR TITLE
ci: stable releases via GitHub Actions manual trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Determine deploy target
         id: target
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "is_stable=true" >> $GITHUB_OUTPUT
           else
             echo "is_stable=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
One-line change: manual "Run workflow" from GitHub Actions (including mobile app) now deploys to stable root instead of `/dev`.

After merging, go to **Actions → Deploy to GitHub Pages → Run workflow** on your phone to deploy current main to stable.

https://claude.ai/code/session_01Ct1HBWSnxNRRA1JbWC3CUD